### PR TITLE
Blog onload bug

### DIFF
--- a/portfolio/src/main/webapp/blogJS.js
+++ b/portfolio/src/main/webapp/blogJS.js
@@ -113,15 +113,6 @@
         }
     }
 
-    // window.onload = function() {
-        // console.log("CREATING displayBlogs");
-        // let displayBlogs = new blogSetup();
-        // console.log("CREATING blogs");
-        // let blogs = displayBlogs.getBlogs();
-        // console.log("LOADING HTML");
-        // displayBlogs.loadHTML(blogs);
-    // }
-
     window.addEventListener('load', (event) => {
         console.log("CREATING displayBlogs");
         let displayBlogs = new blogSetup();

--- a/portfolio/src/main/webapp/blogJS.js
+++ b/portfolio/src/main/webapp/blogJS.js
@@ -113,13 +113,22 @@
         }
     }
 
-    window.onload = function() {
+    // window.onload = function() {
+        // console.log("CREATING displayBlogs");
+        // let displayBlogs = new blogSetup();
+        // console.log("CREATING blogs");
+        // let blogs = displayBlogs.getBlogs();
+        // console.log("LOADING HTML");
+        // displayBlogs.loadHTML(blogs);
+    // }
+
+    window.addEventListener('load', (event) => {
         console.log("CREATING displayBlogs");
         let displayBlogs = new blogSetup();
         console.log("CREATING blogs");
         let blogs = displayBlogs.getBlogs();
         console.log("LOADING HTML");
         displayBlogs.loadHTML(blogs);
-    }
+    });
 
 }


### PR DESCRIPTION
Allows blog posts to be read on window load through an event listener instead of using window.onload which would conflict with footer's use of window.onload